### PR TITLE
Support placement strategies, resolves #20

### DIFF
--- a/modules/backend/ecs.tf
+++ b/modules/backend/ecs.tf
@@ -62,6 +62,14 @@ resource "aws_ecs_service" "this" {
     subnets          = local.subnets
   }
 
+  dynamic "ordered_placement_strategy" {
+    for_each = local.placement_strategies
+    content {
+      field = ordered_placement_strategy.value.field
+      type  = ordered_placement_strategy.value.type
+    }
+  }
+
   tags = local.tags
 }
 

--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -24,6 +24,7 @@ locals {
   instance_count            = var.instances
   listener_arn              = var.listener_arn
   name                      = var.name
+  placement_strategies      = var.placement_strategies
   requires_compatibilities  = var.requires_compatibilities
   routes                    = var.routes
   security_group_id         = var.security_group_id

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -77,6 +77,15 @@ variable "network_mode" {
   default = "awsvpc"
 }
 
+variable "placement_strategies" {
+  default = {
+    pack-by-memory = {
+      field = "memory"
+      type  = "binpack"
+    }
+  }
+}
+
 variable "port" {
   description = "CSpace backend port"
   default     = 8080


### PR DESCRIPTION
Set default placement strategy to pack by memory. Containers will
deployed onto instances that have memory available first, before
scaling out.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html
