### PR TITLE
Support requests for static path

### DIFF
--- a/modules/backend/lb.tf
+++ b/modules/backend/lb.tf
@@ -87,7 +87,8 @@ resource "aws_lb_listener_rule" "app_https_routes_supported" {
         "/cspace/${split(".", each.key)[0]}/*",
         "/cspace-services/*",
         "/cspace-ui/*",
-        "/gateway*"
+        "/gateway*",
+        "/static/*"
       ]
     }
   }


### PR DESCRIPTION
Required for ucb who store images under static/reports/images (and
this can be used for any deployment).
