### PR TITLE
🐛 Allow empty zone_alias

### DIFF
--- a/modules/backend/lb.tf
+++ b/modules/backend/lb.tf
@@ -30,7 +30,7 @@ resource "aws_lb_listener_rule" "app" {
 
   condition {
     host_header {
-      values = distinct(["${local.zone_alias}.${local.hostzone}", "${local.host}"])
+      values = local.host_headers
     }
   }
 }

--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -17,6 +17,8 @@ locals {
   health_check_interval     = var.health_check_interval
   health_check_path         = var.health_check_path
   host                      = var.host
+  host_with_alias           = length(local.zone_alias) > 0 ? "${local.zone_alias}.${local.host}" : local.host
+  host_headers              = distinct([local.host_with_alias, local.host])
   hostzone                  = var.testing ? "test.${var.zone}" : var.zone
   img                       = var.img
   img_tag                   = split(":", var.img)[1]

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -133,5 +133,6 @@ variable "zone" {
 }
 
 variable "zone_alias" {
-  description = "Zone alias"
+  default     = ""
+  description = "Zone alias (a.k.a. subdomain, e.g., 'dev' for dev.collectionspace.org)"
 }


### PR DESCRIPTION
Fixes a bug where Terraform will attempt to create invalid LB listener rule if the zone_alias is empty.