### PR TITLE
🐛 Ensure site name is part of host_header

### DIFF
--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -17,8 +17,9 @@ locals {
   health_check_interval     = var.health_check_interval
   health_check_path         = var.health_check_path
   host                      = var.host
-  host_with_alias           = length(local.zone_alias) > 0 ? "${local.zone_alias}.${local.host}" : local.host
-  host_headers              = distinct([local.host_with_alias, local.host])
+  host_headers              = distinct([local.host_with_alias, local.host_with_site])
+  host_with_alias           = length(local.zone_alias) > 0 ? "${local.zone_alias}.${local.host}" : local.host_with_site
+  host_with_site            = "${local.name}.${local.host}"
   hostzone                  = var.testing ? "test.${var.zone}" : var.zone
   img                       = var.img
   img_tag                   = split(":", var.img)[1]


### PR DESCRIPTION
The previous PR would generate a `host_header` of `collectionspace.org` without a `zone_alias`. What we actually want is the site's name in the `host_header` if there's no `zone_alias`, e.g., `host_header` should be `outreach.collectionspace.org` as opposed to `collectionspace.org`.

The confusion here stems from the use of `zone_alias`. The use of `zone_alias` should be restricted to two cases: 1) a multi-tenant instance like dev where there will be routes for anthro.dev, core.dev, etc., or 2) instances placed within a subdomain for grouping purposes like staging where you have multiple instances that rely on a common subdomain like bplarts.staging, ccp.staging, etc.