### PR TITLE
♻️ Refactoring to clean up DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ module "backend" {
   cluster_id              = var.cluster_id
   container_port          = var.container_port
   efs_id                  = var.efs_id
-  host                    = "example.collectionspace.org"
   img                     = var.backend_img
   listener_arn            = var.listener_arn
   name                    = "cspace-demo"
@@ -34,7 +33,6 @@ module "backend" {
   sns_topic_arn           = var.sns_topic_arn
   subnets                 = var.subnets
   tags                    = {}
-  testing                 = var.testing
   timezone                = "America/New_York"
   vpc_id                  = var.vpc_id
   zone                    = "collectionspace.org"
@@ -43,14 +41,13 @@ module "backend" {
 
 ```
 
-Given this example, the CollectionSpace core profile (if enabled) would be available at:
+Given this example, the CollectionSpace core profile would be available at:
 
-- `https://core.test.collectionspace.org`
+- `https://core.dev.collectionspace.org`
 
-`host`: An additional hostname that the load balancer will forward to the application.  
-`testing`: When `true`, will prefix the zone with `test.`, e.g., `core.collectionspace.org` becomes `core.test.collectionspace.org` when `testing = true`.  
 `zone`: The base TLD under which this instance will be deployed.  
-`zone_alias`: An optional subdomain that the load balancer will forward to the application.  
+`zone_alias`: An optional subdomain prefix that the load balancer will forward to the application.
+Used for multi-tenant cases, e.g., `dev` or `qa` so that sites are, e.g., `core.dev` or `anthro.dev`.
 
 For all configuration options review the [variables file](modules/backend/variables.tf).
 

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -40,7 +40,7 @@ locals {
     Repository = "https://github.com/dts-hosting/terraform-aws-cspace"
   }
 
-  zone = var.testing ? "test.${var.domain}" : var.domain
+  zone = var.domain
 }
 
 ################################################################################
@@ -62,7 +62,6 @@ module "backend" {
   sns_topic_arn     = data.aws_sns_topic.selected.arn
   subnets           = data.aws_subnets.selected.ids
   tags              = local.tags
-  testing           = var.testing
   timezone          = "America/New_York"
   vpc_id            = data.aws_vpc.selected.id
   zone              = var.domain

--- a/examples/services/terraform.tfvars.example
+++ b/examples/services/terraform.tfvars.example
@@ -7,6 +7,5 @@ lb_name                 = "cspace-lb"
 security_group_name     = "cspace-security-group"
 sns_topic_name          = "sns-alert-topic"
 subnet_type             = "Private"
-testing                 = false
 vpc_name                = "cspace-vpc"
 zone_alias              = "test"

--- a/examples/services/variables.tf
+++ b/examples/services/variables.tf
@@ -69,10 +69,6 @@ variable "routes" {
   ]
 }
 
-variable "testing" {
-  default = true
-}
-
 variable "zone_alias" {
   default = "test"
 }

--- a/modules/backend/lb.tf
+++ b/modules/backend/lb.tf
@@ -53,7 +53,7 @@ resource "aws_lb_listener_rule" "app_https_routes" {
 
   condition {
     host_header {
-      values = ["${each.value.name}.${local.hostzone}"]
+      values = ["${each.value.name}.${local.zone}"]
     }
   }
 
@@ -77,7 +77,7 @@ resource "aws_lb_listener_rule" "app_https_routes_supported" {
 
   condition {
     host_header {
-      values = ["${each.value.name}.${local.hostzone}"]
+      values = ["${each.value.name}.${local.zone}"]
     }
   }
 

--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -1,6 +1,6 @@
 locals {
   assign_public_ip          = var.assign_public_ip
-  backend_name              = "${var.name}-backend"
+  backend_name              = local.resource_prefix
   capacity_provider         = var.capacity_provider
   cluster_id                = var.cluster_id
   collectionspace_memory_mb = var.collectionspace_memory_mb
@@ -12,15 +12,13 @@ locals {
   efs_id                    = var.efs_id
   elasticsearch_memory_mb   = var.elasticsearch_memory_mb
   env_cluster_name          = split("/", var.cluster_id)[1]
-  es_efs_name               = "${var.name}-es-data"
+  es_efs_name               = "${local.resource_prefix}-es-data"
+  full_hostname             = "${local.name}.${local.host_with_alias}"
   health_check_attempts     = var.health_check_attempts
   health_check_interval     = var.health_check_interval
   health_check_path         = var.health_check_path
-  host                      = var.host
-  host_headers              = distinct([local.host_with_alias, local.host_with_site])
-  host_with_alias           = length(local.zone_alias) > 0 ? "${local.zone_alias}.${local.host}" : local.host_with_site
-  host_with_site            = "${local.name}.${local.host}"
-  hostzone                  = var.testing ? "test.${var.zone}" : var.zone
+  host_headers              = [local.full_hostname]
+  host_with_alias           = length(local.zone_alias) > 0 ? "${local.zone_alias}.${local.zone}" : local.zone
   img                       = var.img
   img_tag                   = split(":", var.img)[1]
   img_repository            = regex("/(.*):", var.img)[0]
@@ -29,6 +27,7 @@ locals {
   name                      = var.name
   placement_strategies      = var.placement_strategies
   requires_compatibilities  = var.requires_compatibilities
+  resource_prefix           = local.name == local.zone_alias ? local.name : "${local.name}${local.zone_alias}"
   routes                    = var.routes
   security_group_id         = var.security_group_id
   sns_topic_arn             = var.sns_topic_arn

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -129,11 +129,6 @@ variable "task_memory_mb" {
   default     = 3072
 }
 
-variable "testing" {
-  description = "Whether this deployment is for testing (adds .test to the hostname)"
-  default     = false
-}
-
 variable "timezone" {
   description = "Timezone"
 }


### PR DESCRIPTION
Refactors naming to get rid of `host` entirely. There's now `name`, `zone_alias`, and `zone`.

E.g.:
```
name = usopc
zone_alias = staging
zone = collectionspace.org
```

There's a `local.resource_prefix` variable that is equal to `${local.name}${local.zone_alias}` when those values are different or just `local.name` if they're the same. This prefix gets used for the name of the ECS service and the name of the EFS mount. In the above case this would be `usopcstaging`.

These changes also made the `testing` parameter redundant because `zone_alias = test` now has identical functionality.

There will be a follow-up PR to the deployments repo that adapts the existing deployments to the changes here.