### PR TITLE
🐛 Debugging hostname issues

### DIFF
--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -5,7 +5,7 @@ locals {
   cluster_id                = var.cluster_id
   collectionspace_memory_mb = var.collectionspace_memory_mb
   container_port            = var.container_port
-  cpu                       = local.capacity_provider == "EC2" ? null : var.cpu
+  cpu                       = (local.capacity_provider == "EC2" ? null : var.cpu)
   create_db                 = var.create_db
   cspace_memory             = var.collectionspace_memory_mb
   cspace_ui_build           = var.cspace_ui_build
@@ -17,23 +17,26 @@ locals {
   health_check_attempts     = var.health_check_attempts
   health_check_interval     = var.health_check_interval
   health_check_path         = var.health_check_path
-  hostnames = length(local.profiles) == 1 ? [local.full_hostname] : [
+  hostnames = toset(local.is_single_tenant ? [local.full_hostname] : [
     for profile in local.profiles : "${profile}.${local.host_with_alias}"
-  ]
+  ])
   host_headers             = [local.full_hostname]
-  host_with_alias          = length(local.zone_alias) > 0 ? "${local.zone_alias}.${local.zone}" : local.zone
+  host_with_alias          = (local.is_zone_alias ? "${local.zone_alias}.${local.zone}" : local.zone)
   img                      = var.img
   img_tag                  = split(":", var.img)[1]
   img_repository           = regex("/(.*):", var.img)[0]
   instance_count           = var.instances
+  is_alias_eq_name         = (local.zone_alias == local.name)
+  is_single_tenant         = (length(local.profiles) == 1)
+  is_zone_alias            = (length(local.zone_alias) > 0)
   listener_arn             = var.listener_arn
   name                     = var.name
   placement_strategies     = var.placement_strategies
   profiles                 = var.profiles
   requires_compatibilities = var.requires_compatibilities
-  resource_prefix          = local.name == local.zone_alias ? local.name : "${local.name}${local.zone_alias}"
-  route_prefix             = local.name == local.zone_alias ? local.name : "${local.name}.${local.zone_alias}"
-  routes = length(local.profiles) == 1 ? [{
+  resource_prefix          = (local.is_alias_eq_name ? local.name : "${local.name}${local.zone_alias}")
+  route_prefix             = (local.is_alias_eq_name ? local.name : "${local.name}.${local.zone_alias}")
+  routes = (local.is_single_tenant ? [{
     name = local.route_prefix
     host = local.full_hostname
     path = "/cspace/${local.name}/login"
@@ -43,7 +46,7 @@ locals {
       host = "${profile}.${local.host_with_alias}"
       path = "/cspace/${profile}/login"
     }
-  ]
+  ])
   security_group_id     = var.security_group_id
   sns_topic_arn         = var.sns_topic_arn
   subnets               = var.subnets

--- a/modules/backend/outputs.tf
+++ b/modules/backend/outputs.tf
@@ -15,3 +15,7 @@ output "host_with_alias" {
 output "manual_host_with_alias" {
   value = local.is_zone_alias ? "${local.zone_alias}.${local.zone}" : local.zone
 }
+
+output "routes" {
+  value = local.routes
+}

--- a/modules/backend/outputs.tf
+++ b/modules/backend/outputs.tf
@@ -2,3 +2,16 @@ output "hostnames" {
   description = "The hostname(s) expected by the load balancer for the generated routes."
   value       = local.hostnames
 }
+
+# Debugging purposes
+output "full_hostname" {
+  value = local.full_hostname
+}
+
+output "host_with_alias" {
+  value = local.host_with_alias
+}
+
+output "manual_host_with_alias" {
+  value = local.is_zone_alias ? "${local.zone_alias}.${local.zone}" : local.zone
+}


### PR DESCRIPTION
This commit extracts ternary operations to single variables and encloses them in parentheses. During testing of the deployments repo for outreach, it somehow got the `full_hostname` of `outreach.`, so either assignment with ternary operations is happening too soon or the order of local evaluation resulted in `full_hostname` being populated before one of the variables on which it depends (or there's some much more obvious issue that I missed). This is intended to eliminate the first possibility.