### PR TITLE
Add policies to support stats requirements

### DIFF
--- a/modules/backend/iam.tf
+++ b/modules/backend/iam.tf
@@ -25,11 +25,13 @@ resource "aws_iam_role" "this" {
 EOF
 
   managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
     "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
     "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-    "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+    "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess",
+    "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
   ]
 
   inline_policy {


### PR DESCRIPTION
Allow reading from Cloudwatch metrics (s3 storage size)
Enable writes to DynamoDB for storing values from sources (db, s3)
