### PR TITLE
🔥 Remove EFS from hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ module "backend" {
 
   cluster_id              = var.cluster_id
   container_port          = var.container_port
-  efs_id                  = var.efs_id
   extra_hosts             = []
   img                     = var.backend_img
   listener_arn            = var.listener_arn

--- a/REQS.md
+++ b/REQS.md
@@ -13,7 +13,6 @@ As a group the module requires (but does not create):
 - 1+ security group/s that allow ingress from outside the VPC
 - 1+ security group/s that allow ingress from within the VPC
 - An application load balancer assigned to public subnets in the VPC
-- EFS storage for persistent data permitting access from within the VPC
 - ECS cluster / autoscaling group (latter optional if using Fargate)
 - Postgres database (RDS or other) connection details
 - DNS records (Route53 or other) for publicly accessible CSpace services
@@ -25,7 +24,6 @@ are defined, and so on). There are many, many viable ways to do it.
 
 Resources that are "modified" by one or more of the CSpace modules are:
 
-- EFS: access points are created
 - Load balancer: listener rules are created
 
 Therefore it is recommended that these resources be considered "dedicated"

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -54,7 +54,6 @@ module "backend" {
   cluster_id            = data.aws_ecs_cluster.selected.id
   container_port        = var.container_port
   cpu                   = var.cpu
-  efs_id                = data.aws_efs_file_system.selected.id
   img                   = var.backend_img
   listener_arn          = data.aws_lb_listener.selected.arn
   name                  = local.name

--- a/examples/services/terraform.tfvars.example
+++ b/examples/services/terraform.tfvars.example
@@ -2,7 +2,6 @@ backend_img             = "collectionspace/collectionspace:latest"
 cluster_name            = "cspace-cluster"
 container_port          = 8180
 domain                  = "collectionspace.org"
-efs_name                = "cspace-efs"
 extra_hosts             = []
 lb_name                 = "cspace-lb"
 profiles                = ["anthro", "bonsai", "core", "fcart", "herbarium", "lhmc", "materials", "publicart"]

--- a/examples/services/variables.tf
+++ b/examples/services/variables.tf
@@ -43,7 +43,6 @@ variable "service" {}
 ### module
 variable "cluster_name" {}
 variable "cpu" {}
-variable "efs_name" {}
 variable "lb_name" {}
 variable "pathname_override" { default = null }
 variable "profiles" { default = ["anthro", "bonsai", "core", "fcart", "herbarium", "lhmc", "materials", "publicart"] }
@@ -55,12 +54,6 @@ variable "vpc_name" {}
 
 data "aws_ecs_cluster" "selected" {
   cluster_name = var.cluster_name
-}
-
-data "aws_efs_file_system" "selected" {
-  tags = {
-    Name = var.efs_name
-  }
 }
 
 data "aws_lb" "selected" {

--- a/modules/backend/ecs.tf
+++ b/modules/backend/ecs.tf
@@ -13,7 +13,6 @@ resource "aws_ecs_task_definition" "this" {
     create_db            = local.create_db
     cspace_memory        = local.collectionspace_memory_mb
     cspace_ui_build      = local.cspace_ui_build
-    es_efs_name          = local.es_efs_name
     elasticsearch_memory = local.elasticsearch_memory_mb
     img                  = local.img
     log_group_name       = aws_cloudwatch_log_group.this.name
@@ -22,32 +21,6 @@ resource "aws_ecs_task_definition" "this" {
     temp_efs_name        = local.temp_efs_name
     timezone             = local.timezone
   })
-
-  volume {
-    name = local.es_efs_name
-
-    efs_volume_configuration {
-      file_system_id     = local.efs_id
-      transit_encryption = "ENABLED"
-
-      authorization_config {
-        access_point_id = aws_efs_access_point.es.id
-      }
-    }
-  }
-
-  volume {
-    name = local.temp_efs_name
-
-    efs_volume_configuration {
-      file_system_id     = local.efs_id
-      transit_encryption = "ENABLED"
-
-      authorization_config {
-        access_point_id = aws_efs_access_point.temp.id
-      }
-    }
-  }
 }
 
 resource "aws_ecs_service" "this" {
@@ -87,32 +60,6 @@ resource "aws_ecs_service" "this" {
   }
 
   tags = local.tags
-}
-
-resource "aws_efs_access_point" "es" {
-  file_system_id = local.efs_id
-
-  root_directory {
-    path = "/${local.es_efs_name}"
-    creation_info {
-      owner_gid   = 999
-      owner_uid   = 999
-      permissions = "755"
-    }
-  }
-}
-
-resource "aws_efs_access_point" "temp" {
-  file_system_id = local.efs_id
-
-  root_directory {
-    path = "/${local.temp_efs_name}"
-    creation_info {
-      owner_gid   = 999
-      owner_uid   = 999
-      permissions = "755"
-    }
-  }
 }
 
 resource "aws_cloudwatch_log_group" "this" {

--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -9,10 +9,8 @@ locals {
   create_db                 = var.create_db
   cspace_memory             = var.collectionspace_memory_mb
   cspace_ui_build           = var.cspace_ui_build
-  efs_id                    = var.efs_id
   elasticsearch_memory_mb   = var.elasticsearch_memory_mb
   env_cluster_name          = split("/", var.cluster_id)[1]
-  es_efs_name               = "${local.resource_prefix}-es-data"
   extra_hosts               = var.extra_hosts
   full_hostname             = "${coalesce(local.subdomain_override, local.name)}.${local.host_with_alias}"
   health_check_attempts     = var.health_check_attempts

--- a/modules/backend/task-definition/app.json.tpl
+++ b/modules/backend/task-definition/app.json.tpl
@@ -65,13 +65,6 @@
         "value": "-Xms${elasticsearch_memory}m -Xmx${elasticsearch_memory}m"
       }
     ],
-    "mountPoints": [
-      {
-        "sourceVolume": "${es_efs_name}",
-        "containerPath": "/usr/share/elasticsearch/data",
-        "readOnly": false
-      }
-    ],
     %{ if capacity_provider == "EC2" }
     "linuxParameters": {
         "maxSwap": ${swap_size},

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -33,10 +33,6 @@ variable "cspace_ui_build" {
   default = false
 }
 
-variable "efs_id" {
-  description = "EFS id"
-}
-
 variable "elasticsearch_memory_mb" {
   default = 1024
 }


### PR DESCRIPTION
Removes EFS from CSpace hosting since we'll be relying on EBS instance storage after the issues with EFS bursting mode.

This reverts 5e0d713 entirely, as well as removing EFS for ElasticSpace storage. It is also rebased onto the current `main`.

From a pricing perspective, it's probably best if we have two filesystems per application environment: one for ES, holding a steady amount of data long-term and suitable for bursting and one for temporary files that will almost always be empty, but needs high throughput when importing, so should use elastic. This prevents the temporary files from killing all of ES's burst credits which should be sufficient to run things like startups and indexing in a reasonable amount of time.

Mark asked if using EBS for temp/ES would be better over all in terms of predictable costs and performance. I agreed that it would be easier, but am unsure how the pricing compares. Additionally, since there isn't data being shared between systems, there's no reason to use EFS in the first place. We settled on removing EFS entirely and using EBS for ES and temporary files. Mark mentioned that the first thing we need to do is expand the volume size of the ASG instances in infra, so we took care of that last night.