### PR TITLE
♻️ Refactor to avoid deprecated resource arguments

### DIFF
--- a/modules/backend/iam.tf
+++ b/modules/backend/iam.tf
@@ -2,50 +2,53 @@ resource "aws_iam_role" "this" {
   name = local.backend_name
   path = "/"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "ec2.amazonaws.com",
-          "ecs.amazonaws.com",
-          "ecs-tasks.amazonaws.com",
-          "events.amazonaws.com",
-          "lambda.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole",
-      "Sid": ""
-    }
-  ]
+  assume_role_policy = data.aws_iam_policy_document.instance_assume_role_policy.json
 }
-EOF
 
-  managed_policy_arns = [
+resource "aws_iam_role_policy_attachment" "this" {
+  role   = aws_iam_role.this.name
+  policy = aws_iam_role_policy.ECSTaskPassRole.arn
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "this" {
+  role = aws_iam_role.this.name
+  policy_arns = [
     "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
     "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
     "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
     "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess",
-    "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+    "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess",
+    aws_iam_role_policy.ECSTaskPassRole.arn
   ]
+}
 
-  inline_policy {
-    name = "ECSTaskPassRole"
+data "aws_iam_policy_document" "instance_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
 
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Action   = ["iam:PassRole"]
-          Effect   = "Allow"
-          Resource = "*"
-        },
+    principals {
+      type = "Service"
+      identifiers = [
+        "ec2.amazonaws.com",
+        "ecs.amazonaws.com",
+        "ecs-tasks.amazonaws.com",
+        "events.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
-    })
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "ECSTaskPassRole" {
+  name   = "ECSTaskPassRole"
+  policy = data.aws_iam_policy_document.ecs_task_pass_role.json
+}
+
+data "aws_iam_policy_document" "ecs_task_pass_role" {
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = ["*"]
   }
 }


### PR DESCRIPTION
The IAM stuff has changed quite a bit. `managed_policy_arns` and `inline_policy` are deprecated. The `inline_policy`s can be replaced by either creating an `aws_iam_policy` with `policy = jsonencode({...})` or by using the `aws_iam_policy_document` data source that gets referenced by an `aws_iam_policy` and then attached with an `aws_iam_role_policy_attachment`.

`managed_arns` is more complicated because it requires you to use the `aws_iam_role_policy_attachments_exclusive` resource, to which you add your managed ARNs *plus* any previously inline policies that are now attached as `aws_iam_role_policy_attachment`s.

Ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role