### PR TITLE
♻️ Remove `elasticsearch_url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ module "backend" {
 
   cluster_id              = var.cluster_id
   container_port          = var.container_port
-  elasticsearch_url       = "http://localhost:9200"
   extra_hosts             = []
   img                     = var.backend_img
   listener_arn            = var.listener_arn

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -53,7 +53,6 @@ module "backend" {
 
   cluster_id            = data.aws_ecs_cluster.selected.id
   container_port        = var.container_port
-  elasticsearch_url     = "http://${local.name}-es.cspace.elasticsearch:9200"
   iam_ecs_task_role_arn = data.aws_iam_role.ecs_task_role.arn
   img                   = var.backend_img
   listener_arn          = data.aws_lb_listener.selected.arn

--- a/modules/backend/ecs.tf
+++ b/modules/backend/ecs.tf
@@ -13,7 +13,6 @@ resource "aws_ecs_task_definition" "this" {
     create_db         = local.create_db
     cspace_memory     = local.collectionspace_memory_mb
     cspace_ui_build   = local.cspace_ui_build
-    elasticsearch_url = local.elasticsearch_url
     img               = local.img
     log_group_name    = aws_cloudwatch_log_group.this.name
     name              = local.backend_name

--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -13,7 +13,6 @@ locals {
   create_db                 = var.create_db
   cspace_memory             = var.collectionspace_memory_mb
   cspace_ui_build           = var.cspace_ui_build
-  elasticsearch_url         = var.elasticsearch_url
   env_cluster_name          = split("/", var.cluster_id)[1]
   extra_hosts               = var.extra_hosts
   full_hostname             = "${coalesce(local.subdomain_override, local.name)}.${local.host_with_alias}"

--- a/modules/backend/task-definition/app.json.tpl
+++ b/modules/backend/task-definition/app.json.tpl
@@ -23,10 +23,6 @@
         "value": "${cspace_ui_build}"
       },
       {
-        "name": "ES_HOST",
-        "value": "${elasticsearch_url}"
-      },
-      {
         "name": "S3_BINARY_MANAGER_ENABLED",
         "value": "true"
       }

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -40,11 +40,6 @@ variable "cspace_ui_build" {
   default = false
 }
 
-variable "elasticsearch_url" {
-  description = "Elasticsearch URL"
-  default     = "http://localhost:9200"
-}
-
 variable "enable_periodic_build" {
   type        = bool
   default     = false


### PR DESCRIPTION
Per discussion about limiting ES_HOST configuration to docker-cspace.