### PR TITLE
🔥 Remove duplicative `CATALINA_OPTS`

### DIFF
--- a/modules/backend/task-definition/app.json.tpl
+++ b/modules/backend/task-definition/app.json.tpl
@@ -11,10 +11,6 @@
     ],
     "environment": [
       {
-        "name": "CATALINA_OPTS",
-        "value": "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Duser.timezone=${timezone} -Xmx${cspace_memory}m -Xms${cspace_memory}m -XX:MaxPermSize=384m"
-      },
-      {
         "name": "CREATE_DB",
         "value": "${create_db}"
       },


### PR DESCRIPTION
Java 25 doesn't support `MaxPermSize` and we already set `CATALINA_OPTS` as part of docker-cspace. That seemed like the more natural place to configure Catalina.